### PR TITLE
feat: Create Planetastic, an ADSB to Meshtastic Connector

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,28 @@
+# Architecture Notes
+
+This document outlines some of the key design choices made during the development of the Planetastic connector.
+
+## Choice of `dump1090` Data Stream: SBS-1
+
+The script is designed to consume the **SBS-1 (BaseStation)** format data stream from `dump1090` (typically on port 30003). This choice was made after considering the available alternatives.
+
+### Alternatives Considered
+
+1.  **JSON Format:** Most `dump1090` forks provide a JSON endpoint that contains a periodically updated list of all currently tracked aircraft.
+    -   **Pros:** Easy to parse in Python; provides a complete snapshot.
+    -   **Cons:** It is a "pull" model. The script would need to poll this endpoint periodically (e.g., every 5-10 seconds). This adds complexity (managing timers, handling request failures) and can introduce latency. It's less ideal for a real-time, event-driven application.
+
+2.  **Beast Binary Format:** This is a more compact, binary format that provides raw Mode S message data.
+    -   **Pros:** Very efficient and low-latency. It is the "native" format for many decoders.
+    -   **Cons:** Requires a more complex binary parser to decode the messages. While libraries exist for this, it adds a layer of dependency and complexity that is not necessary for our goal of extracting basic position and callsign information.
+
+### Rationale for Choosing SBS-1
+
+The SBS-1 format was chosen as the best compromise for this project's goals:
+
+-   **Simplicity:** It is a simple, line-based, comma-separated text format. This makes it trivial to parse with basic Python string operations, keeping the script lightweight and easy to maintain.
+-   **Real-Time Push Model:** `dump1090` pushes data to the connected client as soon as it's available. This event-driven model is a perfect fit for our application, as we can process messages as they arrive without implementing our own polling logic.
+-   **Broad Compatibility:** The SBS-1 format is a long-standing, de facto standard supported by nearly all `dump1090` forks and many other ADSB decoders. This ensures the script will work for the widest possible range of user setups.
+-   **Sufficient Detail:** While not as detailed as the raw Beast format, the SBS-1 stream contains all the necessary fields (callsign, position, altitude, speed, etc.) to fulfill the requirements of this project.
+
+The main drawback of the SBS-1 format is that data for a single aircraft is fragmented across multiple message types. This was addressed by implementing a stateful in-memory database to aggregate the messages, which provides a robust and reliable way to build a complete picture of each aircraft before broadcasting.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,120 @@
+# Planetastic: An ADSB to Meshtastic Connector
+
+This project provides a Python script, `planetastic.py`, that connects a local ADSB receiver (like `dump1090`) to a Meshtastic network. It listens for aircraft data and broadcasts selected information to your personal mesh or local network.
+
+## How It Works
+
+The script connects to a running `dump1090` instance, which is responsible for receiving and demodulating ADSB signals from an SDR. It reads the parsed aircraft data stream (in SBS-1 format), which is often fragmented across multiple messages for a single aircraft.
+
+To handle this, the script maintains an in-memory database of all aircraft it has seen. As new messages arrive, the script updates the corresponding aircraft's record with the latest information. It will only broadcast an update for an aircraft once its record contains both a callsign and a position.
+
+The script can output the aggregated data in two independent ways:
+
+1.  **To a Meshtastic Device:** Formats a concise text message and sends it to a connected Meshtastic device (either local via USB/Serial or remote via TCP).
+2.  **To the Local Network via MUDP:** Broadcasts each aircraft's information as a `TextMessage` from a single, static gateway node. This allows other applications on the network to see the stream of aircraft data.
+
+These outputs can be used independently or together.
+
+To avoid spamming the network, the script keeps track of each aircraft and only sends an update for a specific aircraft periodically. By default, this interval is 5 minutes (300 seconds), but it can be changed with the `--update-interval` argument.
+
+## Prerequisites
+
+1.  **A functional ADSB receiver.** You need an SDR (like an RTL-SDR dongle) and software to decode the signals. This script is designed to work with `dump1090`. We recommend using a modern fork like [dump1090-fa](https://github.com/flightaware/dump1090) or [readsb](https://github.com/wiedehopf/readsb). Your `dump1090` instance must be configured to provide an SBS-1 BaseStation output stream (usually on port `30003`).
+
+2.  **A Meshtastic device (Optional).** If you want to send messages to the Meshtastic network, you need a compatible LoRa radio connected locally via USB or accessible over your network.
+
+3.  **Python 3.**
+
+## Installation
+
+1.  **Clone this repository.**
+2.  **Install the required Python libraries:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+
+## Usage
+
+Run the script from your terminal. All settings can be controlled by command-line arguments or a configuration file.
+
+### Configuration File
+
+A `config.yaml.example` file is included in the repository. You can copy this file to `config.yaml` and edit it to set your preferred defaults.
+
+```bash
+cp config.yaml.example config.yaml
+```
+
+Then, run the script with the `--config` argument to specify the file's path:
+```bash
+python planetastic.py --config /path/to/your/config.yaml
+```
+
+Any command-line argument will override the values in the configuration file. For example, to use the config file but broadcast to a different MUDP port, you could run:
+```bash
+python planetastic.py --config /path/to/your/config.yaml --mudp-port 9000
+```
+
+### Command-Line Arguments
+
+You can see all available arguments by running:
+```bash
+python planetastic.py --help
+```
+
+-   `--config`: Path to a YAML configuration file.
+-   `--dump1090-host`: The hostname or IP of the `dump1090` instance.
+-   `--dump1090-port`: The port for the `dump1090` SBS-1 stream.
+-   `--meshtastic-host`: The hostname or IP of a network-connected Meshtastic device.
+-   `--meshtastic-port`: The TCP port for the network-connected Meshtastic device.
+-   `--no-meshtastic`: Disables all attempts to connect to a physical Meshtastic device.
+-   `--mudp`: Enable MUDP broadcasting to the local network.
+-   `--mudp-host`: The MUDP multicast group address.
+-   `--mudp-port`: The MUDP multicast port.
+-   `--mudp-node-id`, `--mudp-node-longname`, `--mudp-node-shortname`: Set the static identity for MUDP broadcasts.
+-   `--update-interval`: Seconds before sending a new update for the same aircraft.
+-   `--debug`: Enable debug logging to print raw data from dump1090.
+
+### Examples
+
+**Default behavior (send to local Meshtastic device):**
+```bash
+python planetastic.py
+```
+
+**Broadcast to MUDP only, with updates every 60 seconds:**
+```bash
+python planetastic.py --no-meshtastic --mudp --update-interval 60
+```
+
+**Send to a remote Meshtastic device only:**
+```bash
+python planetastic.py --meshtastic-host 192.168.1.200
+```
+
+**Send to a local Meshtastic device AND broadcast via MUDP:**
+```bash
+python planetastic.py --mudp
+```
+
+## Troubleshooting
+
+### "Connection refused" or No Data
+If you see a "Connection refused" error, or if the script connects but no packets are processed, it usually indicates an issue with the `dump1090` data stream.
+
+-   Ensure your `dump1090` (or equivalent) instance is running.
+-   Check that you are using the correct hostname and port.
+-   Verify that `dump1090` is configured to provide an SBS-1 (BaseStation) data stream on the specified port.
+-   Run this script with the `--debug` flag to see the raw data being received from `dump1090`. If you see raw data but no output, it's likely because the messages being received do not contain both a callsign and a position, which are required for the script to broadcast an update. The debug log will show messages being skipped for this reason.
+
+### No Meshtastic Device Found
+If the script reports "No local Meshtastic device found", it means it could not detect a device connected via USB.
+-   Ensure your device is properly connected.
+-   If your device is network-connected, you must specify its IP address using the `--meshtastic-host` argument.
+
+## Acknowledgements
+
+This project is built upon the great work of the following open-source projects:
+
+-   [Meshtastic Python](https://github.com/meshtastic/python-meshtastic) for communication with Meshtastic devices.
+-   [MUDP](https://github.com/pdxlocations/mudp) for providing a simple way to broadcast Meshtastic-compatible UDP packets.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,37 @@
+# Example configuration file for the ADSB to Meshtastic Connector.
+#
+# To use this file:
+# 1. Copy it to 'config.yaml'
+# 2. Uncomment and edit the settings you want to change.
+# 3. Run the script with the '--config config.yaml' argument.
+#
+# Any command-line argument will override the values in this file.
+
+# --- dump1090 Settings ---
+# The hostname or IP address of your dump1090 instance.
+# dump1090_host: localhost
+# The port for the dump1090 SBS-1 stream.
+# dump1090_port: 30003
+
+# --- Meshtastic Device Settings ---
+# To connect to a remote Meshtastic device over the network, specify its host.
+# If this is commented out, the script will search for a local serial device.
+# meshtastic_host: 192.168.1.100
+# The TCP port for the network-connected Meshtastic device.
+# meshtastic_port: 4403
+# Set to true to disable all attempts to connect to a physical Meshtastic device.
+# no_meshtastic: false
+
+# --- MUDP Broadcasting Settings ---
+# Set to true to enable MUDP broadcasting on the local network.
+# mudp: false
+# The MUDP multicast group address.
+# mudp_host: 224.0.0.69
+# The MUDP multicast port.
+# mudp_port: 4403
+
+# --- MUDP Gateway Identity ---
+# The static node identity to use for all MUDP broadcasts.
+# mudp_node_id: '!adsb-gw'
+# mudp_node_longname: 'ADSB Gateway'
+# mudp_node_shortname: 'ADSB'

--- a/planetastic.py
+++ b/planetastic.py
@@ -1,0 +1,271 @@
+import socket
+import time
+import argparse
+import yaml
+import os
+import meshtastic
+import meshtastic.serial_interface
+import meshtastic.tcp_interface
+try:
+    from mudp import conn, node, send_text_message
+except ImportError:
+    conn = None
+    node = None
+    send_text_message = None
+
+
+# --- Constants ---
+CONNECT_ATTEMPT_DELAY = 5
+CONNECT_ATTEMPT_LIMIT = 10
+
+# --- SBS-1 Message Fields ---
+SBS1_FIELDS = [
+    'message_type', 'transmission_type', 'session_id', 'aircraft_id',
+    'hex_ident', 'flight_id', 'generated_date', 'generated_time',
+    'logged_date', 'logged_time', 'callsign', 'altitude',
+    'ground_speed', 'track', 'lat', 'lon', 'vertical_rate',
+    'squawk', 'alert', 'emergency', 'spi', 'is_on_ground'
+]
+
+def setup_args():
+    """
+    Sets up the command-line arguments, loading defaults from a config file if specified.
+    """
+    # First, parse for the config file path
+    conf_parser = argparse.ArgumentParser(description="A connector between dump1090 and Meshtastic.", add_help=False)
+    conf_parser.add_argument('--config', help='Path to a YAML configuration file.')
+    args, remaining_argv = conf_parser.parse_known_args()
+
+    config = {}
+    if args.config:
+        if os.path.exists(args.config):
+            with open(args.config, 'r') as f:
+                config = yaml.safe_load(f)
+        else:
+            print(f"Warning: Config file not found at {args.config}")
+
+    # Now, parse all arguments, using config file values as defaults
+    parser = argparse.ArgumentParser(parents=[conf_parser])
+    parser.add_argument('--dump1090-host', default=config.get('dump1090_host', 'localhost'), help='The hostname or IP address of the dump1090 instance.')
+    parser.add_argument('--dump1090-port', type=int, default=config.get('dump1090_port', 30003), help='The port for the dump1090 SBS-1 stream.')
+    parser.add_argument('--meshtastic-host', default=config.get('meshtastic_host'), help='The hostname or IP address of the Meshtastic device.')
+    parser.add_argument('--meshtastic-port', type=int, default=config.get('meshtastic_port', 4403), help='The TCP port of the Meshtastic device (default: 4403).')
+    parser.add_argument('--no-meshtastic', action='store_true', default=config.get('no_meshtastic', False), help='Run without connecting to Meshtastic (for debugging).')
+    parser.add_argument('--mudp', action='store_true', default=config.get('mudp', False), help='Enable MUDP broadcasting to the local network.')
+    parser.add_argument('--mudp-host', default=config.get('mudp_host', '224.0.0.69'), help='The MUDP multicast group address (default: 224.0.0.69).')
+    parser.add_argument('--mudp-port', type=int, default=config.get('mudp_port', 4403), help='The MUDP multicast port (default: 4403).')
+    # General arguments
+    parser.add_argument('--update-interval', type=int, default=config.get('update_interval', 300), help='Seconds before sending a new update for the same aircraft.')
+    # MUDP Node Identity Arguments
+    parser.add_argument('--mudp-node-id', default=config.get('mudp_node_id', '!adsb-gw'), help='The static node ID for MUDP broadcasts.')
+    parser.add_argument('--mudp-node-longname', default=config.get('mudp_node_longname', 'ADSB Gateway'), help='The static node long name for MUDP broadcasts.')
+    parser.add_argument('--mudp-node-shortname', default=config.get('mudp_node_shortname', 'ADSB'), help='The static node short name for MUDP broadcasts.')
+
+    # Set defaults from config for boolean flags, allowing command line to override
+    parser.set_defaults(no_meshtastic=config.get('no_meshtastic', False))
+    parser.set_defaults(mudp=config.get('mudp', False))
+    parser.add_argument('--debug', action='store_true', default=config.get('debug', False), help='Enable debug logging to print raw data from dump1090.')
+    parser.set_defaults(debug=config.get('debug', False))
+
+    return parser.parse_args(remaining_argv)
+
+
+def connect_to_dump1090(host, port, debug=False):
+    """
+    Connects to the dump1090 TCP stream and yields lines of data.
+    Handles reconnection logic.
+    If debug is True, prints raw data received.
+    """
+    conn_attempts = 0
+    while conn_attempts < CONNECT_ATTEMPT_LIMIT:
+        try:
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.connect((host, port))
+            print(f"Connected to dump1090 at {host}:{port}")
+
+            buffer = ""
+            while True:
+                data = s.recv(1024).decode('utf-8', errors='ignore')
+                if not data:
+                    break
+
+                if debug:
+                    print(f"DEBUG: Raw data received: {data.strip()}")
+
+                buffer += data
+                while '\n' in buffer:
+                    line, buffer = buffer.split('\n', 1)
+                    yield line
+
+        except socket.error as e:
+            print(f"Error connecting to dump1090 at {host}:{port}: {e}")
+            conn_attempts += 1
+            if conn_attempts < CONNECT_ATTEMPT_LIMIT:
+                print(f"Retrying in {CONNECT_ATTEMPT_DELAY} seconds...")
+                time.sleep(CONNECT_ATTEMPT_DELAY)
+        finally:
+            if 's' in locals() and s:
+                s.close()
+
+    print("Could not connect to dump1090 after multiple attempts. Exiting.")
+    return None
+
+
+def process_adsb_message(message, args, aircraft_db, last_sent_time):
+    """
+    Processes a single ADSB message, updates the aircraft database, and broadcasts if necessary.
+    """
+    parsed_data = parse_adsb_message(message)
+
+    if not parsed_data or not parsed_data.get('hex_ident'):
+        if args.debug and message:
+            print(f"DEBUG: Skipping unparseable or invalid message: {message}")
+        return
+
+    hex_ident = parsed_data['hex_ident']
+
+    # Get or create the aircraft entry in our database
+    aircraft = aircraft_db.get(hex_ident, {})
+
+    # Update the aircraft's data with any new non-empty values
+    for key, value in parsed_data.items():
+        if value is not None and value != '':
+            aircraft[key] = value
+
+    aircraft_db[hex_ident] = aircraft # Store the updated data back
+
+    # Now, check if this aircraft has enough data to be broadcast
+    if aircraft.get('lat') and aircraft.get('callsign'):
+        current_time = time.time()
+
+        # Check rate-limiter
+        if hex_ident not in last_sent_time or \
+           (current_time - last_sent_time[hex_ident]) > args.update_interval:
+
+            # Use the aggregated data from our database for the message
+            aggregated_data = aircraft_db[hex_ident]
+
+            # Send to Meshtastic device
+            if args.meshtastic_interface:
+                meshtastic_msg = format_meshtastic_message(aggregated_data)
+                print(f"Sending to Meshtastic: {meshtastic_msg}")
+                args.meshtastic_interface.sendText(meshtastic_msg)
+
+            # Send to MUDP network
+            if args.mudp and send_text_message:
+                mudp_msg = format_meshtastic_message(aggregated_data)
+                print(f"Broadcasting to MUDP: {mudp_msg}")
+                send_text_message(mudp_msg)
+
+            # If no output methods are active, just print to console
+            if not args.meshtastic_interface and not args.mudp:
+                meshtastic_msg = format_meshtastic_message(aggregated_data)
+                print(f"Output (simulated): {meshtastic_msg}")
+
+            # Update the last sent time
+            last_sent_time[hex_ident] = current_time
+            if args.debug:
+                print(f"DEBUG: Broadcasted update for {hex_ident} ({aircraft.get('callsign').strip()})")
+
+
+def format_meshtastic_message(aircraft_data):
+    """
+    Formats aircraft data into a concise string for Meshtastic.
+    Example: "BAW123 38000ft 51.5N/0.1W"
+    """
+    callsign = aircraft_data.get('callsign', 'N/A').strip()
+    altitude = aircraft_data.get('altitude', 0)
+    lat = aircraft_data.get('lat', 0.0)
+    lon = aircraft_data.get('lon', 0.0)
+
+    # Format latitude and longitude
+    lat_str = f"{abs(lat):.2f}{'N' if lat >= 0 else 'S'}"
+    lon_str = f"{abs(lon):.2f}{'E' if lon >= 0 else 'W'}"
+
+    return f"{callsign} {altitude}ft {lat_str}/{lon_str}"
+
+
+def parse_adsb_message(message_str):
+    """
+    Parses a raw SBS-1 message string into a dictionary.
+    """
+    parts = message_str.strip().split(',')
+    if len(parts) == 22 and parts[0] == 'MSG':
+        # Create a dictionary, replacing empty strings with None
+        msg_data = {key: (val if val else None) for key, val in zip(SBS1_FIELDS, parts)}
+
+        # Clean up and type cast some fields
+        for key in ['transmission_type', 'altitude', 'ground_speed', 'track', 'vertical_rate', 'squawk']:
+            if msg_data.get(key):
+                try:
+                    msg_data[key] = int(msg_data[key])
+                except (ValueError, TypeError):
+                    pass # Keep as None if conversion fails
+
+        for key in ['lat', 'lon']:
+            if msg_data.get(key):
+                try:
+                    msg_data[key] = float(msg_data[key])
+                except (ValueError, TypeError):
+                    pass
+
+        # Booleans
+        for key in ['alert', 'emergency', 'spi', 'is_on_ground']:
+             if msg_data.get(key):
+                msg_data[key] = bool(int(msg_data[key]))
+
+        return msg_data
+    return None
+
+def main():
+    """
+    Main function to run the ADSB to Meshtastic connector.
+    """
+    args = setup_args()
+    print("Starting ADSB to Meshtastic connector...")
+
+    last_sent_time = {}
+    aircraft_db = {}
+
+    args.meshtastic_interface = None
+    if not args.no_meshtastic:
+        try:
+            if args.meshtastic_host:
+                print(f"Attempting to connect to Meshtastic device at {args.meshtastic_host}:{args.meshtastic_port}...")
+                args.meshtastic_interface = meshtastic.tcp_interface.TCPInterface(hostname=args.meshtastic_host, port=args.meshtastic_port)
+            else:
+                print("Attempting to connect to local Meshtastic device via serial...")
+                args.meshtastic_interface = meshtastic.serial_interface.SerialInterface()
+            print("Successfully connected to Meshtastic device.")
+        except Exception as e:
+            if args.meshtastic_host:
+                print(f"Warning: Could not connect to Meshtastic device at {args.meshtastic_host}. {e}")
+            else:
+                print("No local Meshtastic device found.")
+
+    if args.mudp:
+        if conn:
+            print(f"Initializing MUDP broadcasting to {args.mudp_host}:{args.mudp_port}...")
+            conn.setup_multicast(args.mudp_host, args.mudp_port)
+            node.node_id = args.mudp_node_id
+            node.long_name = args.mudp_node_longname
+            node.short_name = args.mudp_node_shortname
+            print(f"MUDP Gateway Node ID: {node.node_id}, Name: {node.long_name}")
+        else:
+            print("MUDP library not found. Please install it with 'pip install mudp'")
+            args.mudp = False
+
+    dump1090_stream = connect_to_dump1090(args.dump1090_host, args.dump1090_port, debug=args.debug)
+
+    if dump1090_stream:
+        try:
+            for message in dump1090_stream:
+                process_adsb_message(message, args, aircraft_db, last_sent_time)
+        except KeyboardInterrupt:
+            print("\nExiting...")
+        finally:
+            if args.meshtastic_interface and hasattr(args.meshtastic_interface, '_socket'):
+                args.meshtastic_interface.close()
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+meshtastic
+mudp
+PyYAML


### PR DESCRIPTION
This commit introduces `planetastic`, a Python application that connects an ADSB data source (like `dump1090`) to a Meshtastic network.

The script connects to a `dump1090` instance, reads the SBS-1 data stream, and aggregates fragmented messages into a stateful, in-memory database of aircraft. Once an aircraft's record contains both a callsign and position, the script broadcasts the information.

Key Features:
- **Stateful Processing:** Correctly handles fragmented SBS-1 messages by aggregating data for each aircraft before broadcasting.
- **Multiple Outputs:**
  - **Meshtastic:** Sends formatted text messages to a physical Meshtastic device (local via serial or remote via TCP).
  - **MUDP:** Broadcasts text messages to the local network via Multicast UDP from a static gateway node, allowing integration with other tools.
- **Flexible Configuration:** All settings can be configured via command-line arguments and/or a `config.yaml` file. An example configuration file is provided.
- **Network Friendly:** Includes a configurable rate-limiter to prevent spamming the network with frequent updates for the same aircraft.
- **Robustness & Debugging:** Features connection retry logic, graceful exit on error, and a `--debug` mode for troubleshooting data flow.
- **Comprehensive Documentation:** Includes a `README.md` with full setup and usage instructions, and an `ARCHITECTURE.md` explaining key design decisions.